### PR TITLE
Update Gens links to use case id

### DIFF
--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -32,7 +32,7 @@
           {% for ind in case.individuals %}
             <tr {% if ind.phenotype_human == 'tumor' %} class="bg-danger-light" {% endif %}>
               <td>{{ ind.display_name }}{% if gens_info.display %}
-                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm float-end" target="_blank" href="http://{{gens_info.host}}/app/viewer/{{case._id}}?sample_ids={{case.individual_ids|join(',')}}&genome_build={{case.genome_build}}">CN profile</a>
+                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm float-end" target="_blank" href="http://{{gens_info.host}}/app/viewer/{{case._id}}?genome_build={{case.genome_build}}">CN profile</a>
                 {% endif %}</td>
               {% if ind.phenotype_human == "normal" %}
                 <td>N/A</td>
@@ -132,7 +132,7 @@
                   </div>
                 </label>
                 {% if gens_info.display %}
-                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm float-end" target="_blank" href="http://{{gens_info.host}}/app/viewer/{{case._id}}?sample_ids={{case.individual_ids|join(',')}}&genome_build={{case.genome_build}}">CN profile</a>
+                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm float-end" target="_blank" href="http://{{gens_info.host}}/app/viewer/{{case._id}}?genome_build={{case.genome_build}}">CN profile</a>
                 {% endif %}
                 </td>
               <td>

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -240,8 +240,7 @@
         <li class="list-group-item">
           <span class="d-inline">Copy number profile</span>
           <span class="d-inline ms-3">
-            {% set sample_ids = case.individual_ids|join(',') %}
-            <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/app/viewer/{{case._id}}?sample_ids={{sample_ids}}&region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}">Gens CN profile</a>
+            <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/app/viewer/{{case._id}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}">Gens CN profile</a>
           </span>
         </li>
         {% endif %}


### PR DESCRIPTION
## Summary
- link to Gens without specifying sample ids

## Testing
- `pytest tests/server/extensions/test_gens_extension.py -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_68678a5ced6c8322a9ec11fcd960a13e